### PR TITLE
Additional fixtures for IPv4 and IPv6 addresses

### DIFF
--- a/dibctl/prepare_os.py
+++ b/dibctl/prepare_os.py
@@ -8,6 +8,7 @@ import os
 import json
 import config
 import ssh
+import ipaddress
 
 
 class TimeoutError(EnvironmentError):
@@ -395,8 +396,19 @@ class PrepOS(object):
 
     def ips(self):
         result = []
-        for ips in self.os_instance.networks.values():
+        for ips in self.os_instance.networks.values():                
             result.extend(ips)
+        return result
+
+    def ips_by_version(self, version=4):
+        result = []
+        for ip in self.ips():
+            # Convert string to unicode object in Python 2.x
+            if sys.version_info < (3, 0):
+                ip = unicode(ip)
+            ipaddr = ipaddress.ip_address(ip)
+            if ipaddr.version == version:
+                result.append(str(ip))
         return result
 
     def network(self):

--- a/dibctl/prepare_os.py
+++ b/dibctl/prepare_os.py
@@ -396,7 +396,7 @@ class PrepOS(object):
 
     def ips(self):
         result = []
-        for ips in self.os_instance.networks.values():                
+        for ips in self.os_instance.networks.values():
             result.extend(ips)
         return result
 

--- a/dibctl/pytest_runner.py
+++ b/dibctl/pytest_runner.py
@@ -24,8 +24,16 @@ class DibCtlPlugin(object):
         return self.tos.flavor().get_keys()
 
     @pytest.fixture
-    def ips_v4(self, request):
+    def ips(self, request):
         return self.tos.ips()
+
+    @pytest.fixture
+    def ips_v4(self, request):
+        return self.tos.ips_by_version(version=4)
+
+    @pytest.fixture
+    def ips_v6(self, request):
+        return self.tos.ips_by_version(version=6)
 
     @pytest.fixture
     def main_ip(self, request):

--- a/docs/tests_examples/pytest.md
+++ b/docs/tests_examples/pytest.md
@@ -11,6 +11,8 @@ List of available fixtures:
 - flavor - information about flavor used to run test instance.
 - flavor_meta - meta information for flavor
 - ips - list of all ips  on all interfaces of instance
+- ips_v4 - list of all IPv4 addresses on all interfaces
+- ips_v6 - same as above with IPv6 addresses
 - main_ip - single value with IPv4, selected according to main_nic_regexp.
 - network - additional information about all interfaces, including expected MAC addresses, subnets, etc.
 - ssh - information about ssh connection to test instance. Includes main ip, path to the private key, username to connect to instance
@@ -31,9 +33,17 @@ flavor_meta fixture
 ---
 It is a dict with key:value structure, containing all metadata for flavor used to start test instance.
 
+ips
+---
+It is a list of all (IPv4 and IPv6) addresses allocated by neutron/nova. Does not include any floatingIPs.
+
 ips_v4
 ---
-It is a list of all ipv4 addresses on allocated by neutron/nova. Do not include any floatingIPs.
+It is a list of all IPv4 addresses on allocated by neutron/nova. Does not include any floatingIPs.
+
+ips_v6
+---
+It is a list of all IPv6 addresses on allocated by neutron/nova. Does not include any floatingIPs.
 
 main_ip
 ---

--- a/tests/test_prepare_os.py
+++ b/tests/test_prepare_os.py
@@ -453,6 +453,35 @@ def test_get_env_config(prepare_os, prep_os):
     assert env['flavor_meta_sentinel.name2'] == 'sentinel.value2'
 
 
+def test_ips(prep_os):
+    prep_os.os_instance.networks = {
+        'net1': [sentinel.ip1],
+        'net2': [sentinel.ip2, sentinel.ip3]
+    }
+    ips = prep_os.ips()
+    assert ips.sort() == [sentinel.ip1, sentinel.ip2, sentinel.ip3].sort()
+
+
+@pytest.mark.parametrize('arg', [None, "somevalue", ''])
+def test_ips_by_version_without_version(prep_os, arg):
+    with mock.patch.object(prep_os, 'ips', return_value=['192.168.0.1', 'fc00::1']):
+        assert prep_os.ips_by_version(arg) == []
+
+
+@pytest.mark.parametrize('version, output', [
+    [4, '192.168.0.1'],
+    [6, 'fc00::1'],
+])
+def test_ips_by_version_valid_version(prep_os, version, output):
+    with mock.patch.object(prep_os, 'ips', return_value=['192.168.0.1', 'fc00::1']):
+        assert prep_os.ips_by_version(version=version) == [output]
+
+
+def test_ips_by_version_invalid_version(prep_os):
+    with mock.patch.object(prep_os, 'ips', return_value=['192.168.0.1', 'fc00::1']):
+        assert prep_os.ips_by_version(version='invalid') == []
+
+
 def test_wait_for_port_never(prepare_os, prep_os, MockSocket):
     with mock.patch.object(prepare_os.time, "time", mock.MagicMock(side_effect=[0, 10, 60, 80])):
         with mock.patch.object(prepare_os, "socket", MockSocket([None])):

--- a/tests/test_pytest_runner.py
+++ b/tests/test_pytest_runner.py
@@ -20,6 +20,12 @@ def ssh():
 
 
 @pytest.fixture
+def prepare_os():
+    from dibctl import prepare_os
+    return prepare_os
+
+
+@pytest.fixture
 def dcp(pytest_runner, ssh):
     tos = mock.MagicMock()
     tos.ip = '192.168.0.1'
@@ -28,6 +34,7 @@ def dcp(pytest_runner, ssh):
     tos.key_name = 'foo-key-name'
     tos.os_key_private_file = 'private-file'
     tos.ips.return_value = [sentinel.ip1, sentinel.ip2]
+    tos.ips_by_version.return_value = [sentinel.ip3, sentinel.ip4]
     s = ssh.SSH('192.168.0.1', 'root', 'secret')
     dcp = pytest_runner.DibCtlPlugin(s, tos, {})
     return dcp
@@ -116,9 +123,11 @@ def test_DibCtlPlugin_wait_for_port_fixture(dcp):
     assert dcp.tos.wait_for_port.call_args == mock.call(22, 60)
 
 
-def test_DibCtlPlugin_ips_v4_fixture(dcp):
-    assert dcp.ips_v4(sentinel.request) == [sentinel.ip1, sentinel.ip2]
+def test_DibCtlPlugin_ips_fixture(dcp):
+    assert dcp.ips(sentinel.request) == [sentinel.ip1, sentinel.ip2]
 
+def test_DibCtlPlugin_ips_v4_fixture(dcp):
+    assert dcp.ips_v4(sentinel.request) == [sentinel.ip3, sentinel.ip4]
 
 def test_DibCtlPlugin_main_ip_fixture(dcp):
     assert dcp.main_ip(sentinel.request) == '192.168.0.1'

--- a/tests/test_pytest_runner.py
+++ b/tests/test_pytest_runner.py
@@ -126,8 +126,10 @@ def test_DibCtlPlugin_wait_for_port_fixture(dcp):
 def test_DibCtlPlugin_ips_fixture(dcp):
     assert dcp.ips(sentinel.request) == [sentinel.ip1, sentinel.ip2]
 
+
 def test_DibCtlPlugin_ips_v4_fixture(dcp):
     assert dcp.ips_v4(sentinel.request) == [sentinel.ip3, sentinel.ip4]
+
 
 def test_DibCtlPlugin_main_ip_fixture(dcp):
     assert dcp.main_ip(sentinel.request) == '192.168.0.1'


### PR DESCRIPTION
IP address filtering by protocol version in prepare_os to fix serverscom/dibctl#1

Changed fixture behaviour: ips_v4 now returns only IPv4 addresses

Fixtures added:
ips - returns all the IP addresses.
ips_v6 - returns only IPv6 addresses