### PR TITLE
Additional fixtures to have access to glance, image config/metadata and console log.

### DIFF
--- a/dibctl/prepare_os.py
+++ b/dibctl/prepare_os.py
@@ -240,6 +240,12 @@ class PrepOS(object):
         )
         return self.ip
 
+    def get_image_info(self):
+        self.image_info = self.get_image(
+            self.os_instance.image['id']
+        )
+        return self.image_info
+
     def wait_for_instance(self, timeout_s):
         print(
             "Waiting for instance to become active (time limit is %s s)" %

--- a/dibctl/pytest_runner.py
+++ b/dibctl/pytest_runner.py
@@ -90,6 +90,22 @@ class DibCtlPlugin(object):
     def nova(self, request):
         return self.os.nova
 
+    @pytest.fixture
+    def glance(self, request):
+        return self.os.glance
+
+    @pytest.fixture
+    def image_info(self, request):
+        return self.tos.get_image_info()
+
+    @pytest.fixture
+    def image_config(self, request):
+        return self.tos.image
+
+    @pytest.fixture
+    def console_output(self, request):
+        return self.tos.os_instance.get_console_output()
+
 
 def runner(path, ssh, tos, environment_variables, timeout_val, continue_on_fail):
     cmdline = [path, '-v', '-s']

--- a/docs/tests_examples/pytest.md
+++ b/docs/tests_examples/pytest.md
@@ -83,3 +83,18 @@ nova
 A fixture to have access to nova client (python-novaclient) with established credentials to
 openstack.
 
+glance
+---
+Fixture returns configured glance client (python-glanceclient) with established session.
+
+image_info
+---
+Glance metadata of the instance's boot image.
+
+image_config
+---
+Dictionary of current image configuration items from `image.yaml`.
+
+console_output
+---
+Text full console log of an instance, stored by OpenStack.

--- a/tests/test_prepare_os.py
+++ b/tests/test_prepare_os.py
@@ -290,6 +290,15 @@ def test_get_instance_main_ip(prep_os):
     assert prep_os.ip == sentinel.ip
 
 
+def test_get_image_info(prep_os):
+    image_info = {'id': sentinel.image, 'filename': sentinel.filename}
+    instance_info = {'id': sentinel.instance, 'image': sentinel.image}
+    prep_os.os_instance.image = instance_info
+    with mock.patch.object(prep_os, 'get_image', return_value=image_info):
+        prep_os.get_image_info()
+    assert prep_os.image_info['id'] == sentinel.image
+
+
 def test_wait_for_instance_error(prepare_os, prep_os):
     prep_os.os_instance = mock.MagicMock(status='ERROR')
     with pytest.raises(prepare_os.InstanceError):

--- a/tests/test_pytest_runner.py
+++ b/tests/test_pytest_runner.py
@@ -35,6 +35,9 @@ def dcp(pytest_runner, ssh):
     tos.os_key_private_file = 'private-file'
     tos.ips.return_value = [sentinel.ip1, sentinel.ip2]
     tos.ips_by_version.return_value = [sentinel.ip3, sentinel.ip4]
+    tos.get_image_info.return_value = sentinel.image_info
+    tos.image = sentinel.image
+    tos.os_instance.get_console_output.return_value = sentinel.console_out
     s = ssh.SSH('192.168.0.1', 'root', 'secret')
     dcp = pytest_runner.DibCtlPlugin(s, tos, {})
     return dcp
@@ -133,6 +136,18 @@ def test_DibCtlPlugin_ips_v4_fixture(dcp):
 
 def test_DibCtlPlugin_main_ip_fixture(dcp):
     assert dcp.main_ip(sentinel.request) == '192.168.0.1'
+
+
+def test_DibCtlPlugin_image_info_fixture(dcp):
+    assert dcp.image_info(sentinel.request) == sentinel.image_info
+
+
+def test_DibCtlPlugin_image_config_fixture(dcp):
+    assert dcp.image_config(sentinel.request) == sentinel.image
+
+
+def test_DibCtlPlugin_console_output_fixture(dcp):
+    assert dcp.console_output(sentinel.request) == sentinel.console_out
 
 
 @pytest.mark.parametrize('key, value', [


### PR DESCRIPTION
Sometimes we need to extract info from instance's console log. I.e: ssh host key, ip addresses assigned to instance, or even output of /etc/issue.

Also added some fixtures to fix #3 

Fixtures added:
`console_output`- string containing all console log stored by Nova.
`glance` - configured instance of python-glanceclient to allow image manipulation in pytest
`image_info` - information about image used to run test instance (from glance)
`image_config` - image configuration from images.yaml
