### PR TITLE
Pass instance of ssh client as a fixture for password authentication.

### DIFF
--- a/dibctl/pytest_runner.py
+++ b/dibctl/pytest_runner.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+import paramiko
 
 
 class DibCtlPlugin(object):
@@ -15,6 +16,7 @@ class DibCtlPlugin(object):
         except ImportError:
             print("Warning: no testinfra installed, ssh_backend fixture is unavaiable")
             self.testinfra = None
+        self.sshclient = paramiko.SSHClient()
 
     @pytest.fixture
     def flavor(self, request):
@@ -105,6 +107,11 @@ class DibCtlPlugin(object):
     @pytest.fixture
     def console_output(self, request):
         return self.tos.os_instance.get_console_output()
+
+    @pytest.fixture
+    def ssh_client(self):
+        self.sshclient.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        return self.sshclient
 
 
 def runner(path, ssh, tos, environment_variables, timeout_val, continue_on_fail):

--- a/docs/tests_examples/pytest.md
+++ b/docs/tests_examples/pytest.md
@@ -98,3 +98,8 @@ Dictionary of current image configuration items from `image.yaml`.
 console_output
 ---
 Text full console log of an instance, stored by OpenStack.
+
+ssh_client
+---
+Unconfigured instance of [paramiko.SSHClient()](https://docs.paramiko.org/en/stable/api/client.html#paramiko.client.SSHClient).
+May be used for testing user authentication with password.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ testinfra
 jsonschema
 urllib3
 semantic_version
+paramiko

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
         'pytest', # not a mistake - we use pytest as a part of the app
         'semantic_version',
         'requests',
-        'urllib3'
+        'urllib3',
+        'paramiko'
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages, Command
 import sys
 from dibctl import version
 
+
 class PyTest(Command):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
@@ -16,11 +17,11 @@ class PyTest(Command):
         import pytest
         print("Running unit tests")
         error_code = pytest.main([
-			'build',
-			'--ignore', 'build/doctests',
-			'--ignore', 'build/tests/test_bad_configs.py',
-			'--ignore', 'build/integration_tests'
-		])
+            'build',
+            '--ignore', 'build/doctests',
+            '--ignore', 'build/tests/test_bad_configs.py',
+            '--ignore', 'build/integration_tests'
+        ])
         if error_code:
             sys.exit(error_code)
         print("Running integration tests for docs examples")
@@ -48,7 +49,7 @@ setup(
         'python-novaclient',
         'pytest-timeout',
         'jsonschema',
-        'pytest', # not a mistake - we use pytest as a part of the app
+        'pytest',  # not a mistake - we use pytest as a part of the app
         'semantic_version',
         'requests',
         'urllib3',

--- a/tests/test_pytest_runner.py
+++ b/tests/test_pytest_runner.py
@@ -5,6 +5,7 @@ import os
 import inspect
 import sys
 from mock import sentinel
+import paramiko
 
 
 @pytest.fixture
@@ -148,6 +149,10 @@ def test_DibCtlPlugin_image_config_fixture(dcp):
 
 def test_DibCtlPlugin_console_output_fixture(dcp):
     assert dcp.console_output(sentinel.request) == sentinel.console_out
+
+
+def test_DibCtlPlugin_ssh_client_fixture(dcp):
+    assert isinstance(dcp.ssh_client(), paramiko.client.SSHClient)
 
 
 @pytest.mark.parametrize('key, value', [


### PR DESCRIPTION
Testinfra does not allow us to connect to the instance with login/password so far ([issue](https://github.com/philpep/testinfra/issues/34)) but password authentication is a common case, so we need to test it.

There are two most straightforward ways to test password authentication: 
1. Call the ssh binary and use expect/pexpect to interact with console
2. Use paramiko (python implementation of the SSHv2 protocol) with password authentication.

IMHO, the second is more "pythonic", than handling subprocesses, so i suggest passing instance of paramiko.SSHClient() as a pytest fixture to ease the password login.