### PR TITLE
Fix locations of nova and glance fixtures

### DIFF
--- a/dibctl/pytest_runner.py
+++ b/dibctl/pytest_runner.py
@@ -90,11 +90,11 @@ class DibCtlPlugin(object):
 
     @pytest.fixture
     def nova(self, request):
-        return self.os.nova
+        return self.tos.os.nova
 
     @pytest.fixture
     def glance(self, request):
-        return self.os.glance
+        return self.tos.os.glance
 
     @pytest.fixture
     def image_info(self, request):


### PR DESCRIPTION
Nova and glance fixture are broken, cause `DibCtlPlugin` does not have attribute `os`.