### PR TITLE
fix: convert all properties to string

### DIFF
--- a/dibctl/osclient.py
+++ b/dibctl/osclient.py
@@ -393,7 +393,8 @@ class OSClient(object):
             protected=protected,
 
         )
-        self.glance.images.update(img.id, **dict(meta))
+        cleanup_meta = dict((str(k),str(v)) for (k,v) in meta.items())  # force everything to stringify
+        self.glance.images.update(img.id, **dict(cleanup_meta))
         self.glance.images.upload(img.id, self._file_to_upload(filename))
 
 

--- a/dibctl/version.py
+++ b/dibctl/version.py
@@ -1,3 +1,3 @@
-VERSION = '0.8.0'
+VERSION = '0.8.1'
 NAME = 'dibctl'
 VERSION_STRING = "%s %s" % (NAME, VERSION)


### PR DESCRIPTION
Glance library no longer accepts 'repr' values, and requires strings for properties.